### PR TITLE
fix: persist in-memory torrent cache to disk to prevent duplicate notifications on restart

### DIFF
--- a/docs/getting_started/configuration_file.md
+++ b/docs/getting_started/configuration_file.md
@@ -51,11 +51,9 @@ Defines the qBittorrent client configuration.
 
 ## Redis
 
-Redis stores temporary runtime data. If omitted or `url` is `null`, an **in-memory dictionary** is used.
+Redis stores runtime data used to track which completed torrents have already triggered a notification, preventing duplicate alerts across restarts.
 
-!!!warning
-Using in-memory storage is **not recommended for production** — all data is lost when the bot restarts.
-!!!
+If `url` is `null` or omitted, the bot falls back to a file-backed in-memory store that persists its state to `data/torrent_cache.json`. This is suitable for single-instance setups. Redis is recommended for production or multi-instance deployments.
 
 | Name | Type                  | Remarks                                               |
 | ---- | --------------------- | ----------------------------------------------------- |

--- a/src/main.py
+++ b/src/main.py
@@ -47,7 +47,10 @@ async def main(base_path: Path) -> None:
     i18n = I18n(path=locales_path, default_locale="en", domain="messages")
 
     # create Redis client
-    redis_client = RedisWrapper(url=settings.redis.url)
+    redis_client = RedisWrapper(
+        url=settings.redis.url,
+        persist_path=base_path / "data" / "torrent_cache.json"
+    )
     await redis_client.connect()
 
     # register it in dp.dependencies

--- a/src/redis_helper/emulator.py
+++ b/src/redis_helper/emulator.py
@@ -15,6 +15,10 @@ class RedisEmulator:
         self._persist_path = persist_path
         self._load()
 
+    @property
+    def persist_path(self) -> Optional[Path]:
+        return self._persist_path
+
     def _load(self):
         if not self._persist_path or not self._persist_path.exists():
             return
@@ -63,11 +67,11 @@ class RedisEmulator:
 
     async def set(self, key: str, value: Any, ex: int | None = None) -> None:
         async with self._lock:
-            expires_at = time.time() + ex if ex else None
+            expires_at = time.time() + ex if ex is not None else None
             self._storage[key] = {"value": value, "expires_at": expires_at}
             snapshot = dict(self._storage)
         self._save(snapshot)
-        if ex:
+        if ex is not None:
             asyncio.create_task(self._expire(key, expires_at))
 
     async def delete(self, key: str) -> None:

--- a/src/redis_helper/emulator.py
+++ b/src/redis_helper/emulator.py
@@ -2,12 +2,14 @@ import asyncio
 import json
 import time
 import logging
+import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
 
 class RedisEmulator:
     def __init__(self, persist_path: Optional[Path] = None):
+        """In-memory Redis emulator with optional JSON persistence across restarts."""
         self._storage: dict[str, dict] = {}
         self._lock = asyncio.Lock()
         self._persist_path = persist_path
@@ -18,7 +20,7 @@ class RedisEmulator:
             return
 
         try:
-            with open(self._persist_path, "r") as f:
+            with open(self._persist_path, "r", encoding="utf-8") as f:
                 raw = json.load(f)
 
             now = time.time()
@@ -35,8 +37,12 @@ class RedisEmulator:
 
         try:
             self._persist_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._persist_path, "w") as f:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", dir=self._persist_path.parent, delete=False, suffix=".tmp"
+            ) as f:
                 json.dump(self._storage, f)
+                tmp = Path(f.name)
+            tmp.replace(self._persist_path)
         except Exception as e:
             logging.warning(f"Could not persist emulator state to disk: {e}")
 
@@ -44,6 +50,11 @@ class RedisEmulator:
         async with self._lock:
             entry = self._storage.get(key)
             if entry is None:
+                return None
+            expires_at = entry.get("expires_at")
+            if expires_at is not None and time.time() > expires_at:
+                self._storage.pop(key)
+                self._save()
                 return None
             return entry["value"]
 

--- a/src/redis_helper/emulator.py
+++ b/src/redis_helper/emulator.py
@@ -31,7 +31,7 @@ class RedisEmulator:
         except Exception as e:
             logging.warning(f"Could not load emulator state from disk: {e}")
 
-    def _save(self):
+    def _save(self, snapshot: dict) -> None:
         if not self._persist_path:
             return
 
@@ -40,13 +40,14 @@ class RedisEmulator:
             with tempfile.NamedTemporaryFile(
                 "w", encoding="utf-8", dir=self._persist_path.parent, delete=False, suffix=".tmp"
             ) as f:
-                json.dump(self._storage, f)
+                json.dump(snapshot, f)
                 tmp = Path(f.name)
             tmp.replace(self._persist_path)
         except Exception as e:
             logging.warning(f"Could not persist emulator state to disk: {e}")
 
     async def get(self, key: str) -> Optional[Any]:
+        snapshot = None
         async with self._lock:
             entry = self._storage.get(key)
             if entry is None:
@@ -54,25 +55,29 @@ class RedisEmulator:
             expires_at = entry.get("expires_at")
             if expires_at is not None and time.time() > expires_at:
                 self._storage.pop(key)
-                self._save()
-                return None
-            return entry["value"]
+                snapshot = dict(self._storage)
+            else:
+                return entry["value"]
+        self._save(snapshot)
+        return None
 
     async def set(self, key: str, value: Any, ex: int | None = None) -> None:
         async with self._lock:
             expires_at = time.time() + ex if ex else None
             self._storage[key] = {"value": value, "expires_at": expires_at}
-            self._save()
-
+            snapshot = dict(self._storage)
+        self._save(snapshot)
         if ex:
-            asyncio.create_task(self._expire(key, ex))
+            asyncio.create_task(self._expire(key, expires_at))
 
     async def delete(self, key: str) -> None:
         async with self._lock:
             self._storage.pop(key, None)
-            self._save()
+            snapshot = dict(self._storage)
+        self._save(snapshot)
 
     async def exists(self, key: str) -> bool:
+        snapshot = None
         async with self._lock:
             entry = self._storage.get(key)
             if entry is None:
@@ -80,12 +85,21 @@ class RedisEmulator:
             expires_at = entry.get("expires_at")
             if expires_at is not None and time.time() > expires_at:
                 self._storage.pop(key, None)
-                self._save()
-                return False
-            return True
+                snapshot = dict(self._storage)
+                result = False
+            else:
+                result = True
+        if snapshot is not None:
+            self._save(snapshot)
+        return result
 
-    async def _expire(self, key: str, seconds: int):
-        await asyncio.sleep(seconds)
+    async def _expire(self, key: str, expires_at: float):
+        await asyncio.sleep(max(0, expires_at - time.time()))
+        snapshot = None
         async with self._lock:
-            self._storage.pop(key, None)
-            self._save()
+            entry = self._storage.get(key)
+            if entry is not None and entry.get("expires_at") == expires_at:
+                self._storage.pop(key)
+                snapshot = dict(self._storage)
+        if snapshot is not None:
+            self._save(snapshot)

--- a/src/redis_helper/emulator.py
+++ b/src/redis_helper/emulator.py
@@ -1,32 +1,80 @@
 import asyncio
+import json
+import time
+import logging
+from pathlib import Path
 from typing import Any, Optional
 
 
 class RedisEmulator:
-    def __init__(self):
-        self._storage: dict[str, Any] = {}
+    def __init__(self, persist_path: Optional[Path] = None):
+        self._storage: dict[str, dict] = {}
         self._lock = asyncio.Lock()
+        self._persist_path = persist_path
+        self._load()
+
+    def _load(self):
+        if not self._persist_path or not self._persist_path.exists():
+            return
+
+        try:
+            with open(self._persist_path, "r") as f:
+                raw = json.load(f)
+
+            now = time.time()
+            self._storage = {
+                k: v for k, v in raw.items()
+                if v.get("expires_at") is None or v["expires_at"] > now
+            }
+        except Exception as e:
+            logging.warning(f"Could not load emulator state from disk: {e}")
+
+    def _save(self):
+        if not self._persist_path:
+            return
+
+        try:
+            self._persist_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._persist_path, "w") as f:
+                json.dump(self._storage, f)
+        except Exception as e:
+            logging.warning(f"Could not persist emulator state to disk: {e}")
 
     async def get(self, key: str) -> Optional[Any]:
         async with self._lock:
-            return self._storage.get(key)
+            entry = self._storage.get(key)
+            if entry is None:
+                return None
+            return entry["value"]
 
     async def set(self, key: str, value: Any, ex: int | None = None) -> None:
         async with self._lock:
-            self._storage[key] = value
+            expires_at = time.time() + ex if ex else None
+            self._storage[key] = {"value": value, "expires_at": expires_at}
+            self._save()
 
-            if ex:
-                asyncio.create_task(self._expire(key, ex))
+        if ex:
+            asyncio.create_task(self._expire(key, ex))
 
     async def delete(self, key: str) -> None:
         async with self._lock:
             self._storage.pop(key, None)
+            self._save()
 
     async def exists(self, key: str) -> bool:
         async with self._lock:
-            return key in self._storage
+            entry = self._storage.get(key)
+            if entry is None:
+                return False
+            expires_at = entry.get("expires_at")
+            if expires_at is not None and time.time() > expires_at:
+                self._storage.pop(key, None)
+                self._save()
+                return False
+            return True
 
     async def _expire(self, key: str, seconds: int):
         await asyncio.sleep(seconds)
         async with self._lock:
             self._storage.pop(key, None)
+            self._save()

--- a/src/redis_helper/emulator.py
+++ b/src/redis_helper/emulator.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 class RedisEmulator:
     def __init__(self, persist_path: Optional[Path] = None):
         """In-memory Redis emulator with optional JSON persistence across restarts."""
-        self._storage: dict[str, dict] = {}
+        self._storage: dict[str, dict[str, Any]] = {}
         self._lock = asyncio.Lock()
         self._persist_path = persist_path
         self._load()
@@ -72,11 +72,11 @@ class RedisEmulator:
 
     async def set(self, key: str, value: Any, ex: int | None = None) -> None:
         async with self._lock:
-            expires_at = time.time() + ex if ex is not None else None
+            expires_at = time.time() + ex if ex is not None and ex > 0 else None
             self._storage[key] = {"value": value, "expires_at": expires_at}
             snapshot = dict(self._storage)
         self._save(snapshot)
-        if ex is not None:
+        if ex is not None and ex > 0:
             asyncio.create_task(self._expire(key, expires_at))
 
     async def delete(self, key: str) -> None:

--- a/src/redis_helper/emulator.py
+++ b/src/redis_helper/emulator.py
@@ -28,12 +28,17 @@ class RedisEmulator:
                 raw = json.load(f)
 
             now = time.time()
-            self._storage = {
-                k: v for k, v in raw.items()
-                if v.get("expires_at") is None or v["expires_at"] > now
-            }
+            normalized = {}
+            for k, v in raw.items():
+                # accept both the current {"value":…,"expires_at":…} shape and
+                # any older flat {key: value} shape written by a previous version
+                if not isinstance(v, dict) or "value" not in v:
+                    v = {"value": v, "expires_at": None}
+                if v.get("expires_at") is None or v["expires_at"] > now:
+                    normalized[k] = v
+            self._storage = normalized
         except Exception as e:
-            logging.warning(f"Could not load emulator state from disk: {e}")
+            logging.exception(f"Could not load emulator state from disk: {e}")
 
     def _save(self, snapshot: dict) -> None:
         if not self._persist_path:
@@ -48,7 +53,7 @@ class RedisEmulator:
                 tmp = Path(f.name)
             tmp.replace(self._persist_path)
         except Exception as e:
-            logging.warning(f"Could not persist emulator state to disk: {e}")
+            logging.exception(f"Could not persist emulator state to disk: {e}")
 
     async def get(self, key: str) -> Optional[Any]:
         snapshot = None

--- a/src/redis_helper/wrapper.py
+++ b/src/redis_helper/wrapper.py
@@ -12,7 +12,7 @@ except ImportError:
 
 class RedisWrapper:
     def __init__(self, url: Optional[str] = None, persist_path: Optional[Path] = None):
-        """Unified Redis client that falls back to a persistent in-memory emulator when no URL is given."""
+        """Unified Redis client; falls back to an in-memory emulator (file-backed if persist_path is set) when no URL is given."""
         self._url = url
         self._client = None
         self._emulator = RedisEmulator(persist_path=persist_path)

--- a/src/redis_helper/wrapper.py
+++ b/src/redis_helper/wrapper.py
@@ -19,7 +19,10 @@ class RedisWrapper:
 
     async def connect(self):
         if not self._url or not redis:
-            logging.warning("Redis disabled. using in-memory storage")
+            if self._emulator._persist_path:
+                logging.warning(f"Redis disabled, using file-backed emulator ({self._emulator._persist_path})")
+            else:
+                logging.warning("Redis disabled, using in-memory emulator (data will not survive restarts)")
             self._client = self._emulator
             return
 
@@ -29,7 +32,10 @@ class RedisWrapper:
             self._client = client
             logging.info("Connected to Redis")
         except Exception as e:
-            logging.warning(f"Redis unavailable ({e}), using in-memory storage")
+            if self._emulator._persist_path:
+                logging.warning(f"Redis unavailable ({e}), falling back to file-backed emulator ({self._emulator._persist_path})")
+            else:
+                logging.warning(f"Redis unavailable ({e}), falling back to in-memory emulator (data will not survive restarts)")
             self._client = self._emulator
 
     # Unified API

--- a/src/redis_helper/wrapper.py
+++ b/src/redis_helper/wrapper.py
@@ -19,8 +19,8 @@ class RedisWrapper:
 
     async def connect(self):
         if not self._url or not redis:
-            if self._emulator._persist_path:
-                logging.warning(f"Redis disabled, using file-backed emulator ({self._emulator._persist_path})")
+            if self._emulator.persist_path:
+                logging.warning(f"Redis disabled, using file-backed emulator ({self._emulator.persist_path})")
             else:
                 logging.warning("Redis disabled, using in-memory emulator (data will not survive restarts)")
             self._client = self._emulator
@@ -32,8 +32,8 @@ class RedisWrapper:
             self._client = client
             logging.info("Connected to Redis")
         except Exception as e:
-            if self._emulator._persist_path:
-                logging.warning(f"Redis unavailable ({e}), falling back to file-backed emulator ({self._emulator._persist_path})")
+            if self._emulator.persist_path:
+                logging.warning(f"Redis unavailable ({e}), falling back to file-backed emulator ({self._emulator.persist_path})")
             else:
                 logging.warning(f"Redis unavailable ({e}), falling back to in-memory emulator (data will not survive restarts)")
             self._client = self._emulator

--- a/src/redis_helper/wrapper.py
+++ b/src/redis_helper/wrapper.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Any, Optional
 
 from .emulator import RedisEmulator
@@ -10,10 +11,10 @@ except ImportError:
 
 
 class RedisWrapper:
-    def __init__(self, url: Optional[str] = None):
+    def __init__(self, url: Optional[str] = None, persist_path: Optional[Path] = None):
         self._url = url
         self._client = None
-        self._emulator = RedisEmulator()
+        self._emulator = RedisEmulator(persist_path=persist_path)
 
     async def connect(self):
         if not self._url or not redis:

--- a/src/redis_helper/wrapper.py
+++ b/src/redis_helper/wrapper.py
@@ -12,6 +12,7 @@ except ImportError:
 
 class RedisWrapper:
     def __init__(self, url: Optional[str] = None, persist_path: Optional[Path] = None):
+        """Unified Redis client that falls back to a persistent in-memory emulator when no URL is given."""
         self._url = url
         self._client = None
         self._emulator = RedisEmulator(persist_path=persist_path)


### PR DESCRIPTION
Without Redis configured, the fallback RedisEmulator stored seen torrent hashes in memory only, causing completed torrents to re-trigger Telegram notifications on every bot restart. The emulator now saves its state (including TTL timestamps) to data/torrent_cache.json and reloads it on startup, filtering out any expired entries.

Docker container logs:
```
Bytecode compiled 1337 files in 114ms
2026-06-12 05:36:18,166 - asyncio - DEBUG - Using selector: EpollSelector
2026-06-12 05:36:18,187 - root - WARNING - Redis disabled, using file-backed emulator (/app/data/torrent_cache.json)
2026-06-12 05:36:18,194 - tzlocal - DEBUG - /etc/timezone found, contents:
 Etc/UTC
...
```